### PR TITLE
Ignore detective_connect.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# File used by https://detective.dev/, containing the VM service socket URL of
+# the currently running app
+detective_connect.txt
+
 # Miscellaneous
 *.class
 *.log


### PR DESCRIPTION
This file contains the VM service socket URL, and is specific to the running application. Used by https://detective.dev/

